### PR TITLE
Remove wrong @return array from StatsdDataFactoryInterface

### DIFF
--- a/src/Liuggio/StatsdClient/Factory/StatsdDataFactoryInterface.php
+++ b/src/Liuggio/StatsdClient/Factory/StatsdDataFactoryInterface.php
@@ -43,8 +43,6 @@ Interface StatsdDataFactoryInterface
      *
      * @param  string|array $key   The metric(s) to set.
      * @param  float        $value The value for the stats.
-     *
-     * @return array
      **/
     function set($key, $value);
 
@@ -55,8 +53,6 @@ Interface StatsdDataFactoryInterface
      *
      * @param string|array $key        The metric(s) to increment.
      * @param float|1      $sampleRate The rate (0-1) for sampling.
-     *
-     * @return array
      **/
     function increment($key);
 
@@ -67,8 +63,6 @@ Interface StatsdDataFactoryInterface
      *
      * @param string|array $key        The metric(s) to decrement.
      * @param float|1      $sampleRate The rate (0-1) for sampling.
-     *
-     * @return mixed
      **/
     function decrement($key);
 
@@ -79,8 +73,6 @@ Interface StatsdDataFactoryInterface
      *
      * @param string|array $key        The metric(s) to decrement.
      * @param integer      $delta      The delta to add to the each metric
-     *
-     * @return mixed
      **/
     function updateCount($key, $delta);
 


### PR DESCRIPTION
Most methods have either no `@return` or `@return mixed`, which
allows implementations to use a buffer or otherwise have deferred or
void methods. I believe that part is intentional since the internal
objects from StatsdDataInterface as returned via produceStatsdData in
the default implementation are afaik never used by end-users.

The set() and increment() methods had a phpdoc `@return array` which
appears to be there by mistake, as StatsdDataFactory actually does
not return array for those methods.

In Wikimedia's BufferingStatsdDataFactory implementation this led to
warnings from Phan static analysis, such as:

> PhanTypeMissingReturn Method BufferingStatsdDataFactory::set is
> declared to return array in phpdoc but has no return value
> PhanTypeMissingReturn Method BufferingStatsdDataFactory::increment
> is declared to return array in phpdoc but has no return value

Remove these for consistency with timing() and gauge(), and so that
downstream can eventually remove suppressions for these issues.